### PR TITLE
add support for lnrpc subservices

### DIFF
--- a/lib/autopilot.js
+++ b/lib/autopilot.js
@@ -1,0 +1,61 @@
+const {promisify} = require('util');
+
+const DEFAULTS = {
+  subscriptionMethods: [
+
+  ],
+};
+
+/**
+ * Factory for a Autopilot GRPC service proxy
+ *
+ * Proxy serves two purposes:
+ *  - Wrap non-subscription methods in promises
+ *  - Immediately return subscription methods and properties
+ *
+ * @param  {grpc.PackageDefinition}   lnrpcDescriptor
+ * @param  {String}                   server
+ * @param  {Object}                   credentials
+ * @param  {Object}                   config
+ * @return {Proxy}
+ */
+module.exports = function createAutopilotProxy(
+  lnrpcDescriptor,
+  server,
+  credentials,
+  config = {}
+) {
+  // Configuration options
+  const {subscriptionMethods} = Object.assign({}, DEFAULTS, config);
+
+  /**
+   * GRPC Autopilot Service
+   * @type {lnrpc.Autopilot}
+   */
+  let autopilot;
+
+  try {
+    autopilot = new lnrpcDescriptor.autopilotrpc.Autopilot(server, credentials);
+  } catch (e) {
+    if (!e.code) e.code = 'GRPC_AUTOPILOT_SERVICE_ERR';
+    throw e;
+  }
+
+  return new Proxy(autopilot, {
+    /**
+     * Promisify any requested (non-subscription) autopilot RPC method
+     * @param  {lnrpc.Autopilot} target
+     * @param  {String}          key
+     * @return {Any}
+     */
+    get(target, key) {
+      const method = target[key];
+
+      if (typeof method !== 'function' || subscriptionMethods.includes(key)) {
+        return target[key]; // forward
+      } else {
+        return promisify(method);
+      }
+    },
+  });
+};

--- a/lib/chain-notifier.js
+++ b/lib/chain-notifier.js
@@ -1,0 +1,63 @@
+const {promisify} = require('util');
+
+const DEFAULTS = {
+  subscriptionMethods: [
+    'registerConfirmationsNtfn',
+    'registerSpendNtfn',
+    'registerBlockEpochNtfn'
+  ],
+};
+
+/**
+ * Factory for a ChainNotifier GRPC service proxy
+ *
+ * Proxy serves two purposes:
+ *  - Wrap non-subscription methods in promises
+ *  - Immediately return subscription methods and properties
+ *
+ * @param  {grpc.PackageDefinition}   lnrpcDescriptor
+ * @param  {String}                   server
+ * @param  {Object}                   credentials
+ * @param  {Object}                   config
+ * @return {Proxy}
+ */
+module.exports = function createChainNotifierProxy(
+  lnrpcDescriptor,
+  server,
+  credentials,
+  config = {}
+) {
+  // Configuration options
+  const {subscriptionMethods} = Object.assign({}, DEFAULTS, config);
+
+  /**
+   * GRPC ChainNotifier Service
+   * @type {lnrpc.ChainNotifier}
+   */
+  let chainNotifier;
+
+  try {
+    chainNotifier = new lnrpcDescriptor.chainrpc.ChainNotifier(server, credentials);
+  } catch (e) {
+    if (!e.code) e.code = 'GRPC_CHAIN_NOTIFIER_SERVICE_ERR';
+    throw e;
+  }
+
+  return new Proxy(chainNotifier, {
+    /**
+     * Promisify any requested (non-subscription) chainNotifier RPC method
+     * @param  {lnrpc.ChainNotifier} target
+     * @param  {String}          key
+     * @return {Any}
+     */
+    get(target, key) {
+      const method = target[key];
+
+      if (typeof method !== 'function' || subscriptionMethods.includes(key)) {
+        return target[key]; // forward
+      } else {
+        return promisify(method);
+      }
+    },
+  });
+};

--- a/lib/invoices.js
+++ b/lib/invoices.js
@@ -1,0 +1,61 @@
+const {promisify} = require('util');
+
+const DEFAULTS = {
+  subscriptionMethods: [
+    'subscribeSingleInvoice',
+  ],
+};
+
+/**
+ * Factory for a Invoices GRPC service proxy
+ *
+ * Proxy serves two purposes:
+ *  - Wrap non-subscription methods in promises
+ *  - Immediately return subscription methods and properties
+ *
+ * @param  {grpc.PackageDefinition}   lnrpcDescriptor
+ * @param  {String}                   server
+ * @param  {Object}                   credentials
+ * @param  {Object}                   config
+ * @return {Proxy}
+ */
+module.exports = function createInvoicesProxy(
+  lnrpcDescriptor,
+  server,
+  credentials,
+  config = {}
+) {
+  // Configuration options
+  const {subscriptionMethods} = Object.assign({}, DEFAULTS, config);
+
+  /**
+   * GRPC Invoices Service
+   * @type {lnrpc.Invoices}
+   */
+  let invoices;
+
+  try {
+    invoices = new lnrpcDescriptor.invoicesrpc.Invoices(server, credentials);
+  } catch (e) {
+    if (!e.code) e.code = 'GRPC_INVOICES_SERVICE_ERR';
+    throw e;
+  }
+
+  return new Proxy(invoices, {
+    /**
+     * Promisify any requested (non-subscription) invoices RPC method
+     * @param  {lnrpc.Invoices} target
+     * @param  {String}          key
+     * @return {Any}
+     */
+    get(target, key) {
+      const method = target[key];
+
+      if (typeof method !== 'function' || subscriptionMethods.includes(key)) {
+        return target[key]; // forward
+      } else {
+        return promisify(method);
+      }
+    },
+  });
+};

--- a/lib/lnrpc.js
+++ b/lib/lnrpc.js
@@ -6,6 +6,14 @@ const protoLoader = require('@grpc/proto-loader');
 const GRPC = require('grpc');
 const createLightning = require('./lightning');
 const createWalletUnlocker = require('./wallet-unlocker');
+const createAutopilot = require('./autopilot');
+const createSigner = require('./signer');
+const createChainNotifier = require('./chain-notifier');
+const createInvoices = require('./invoices');
+const createRouter = require('./router');
+const createWalletKit = require('./wallet-kit');
+const createWatchtower = require('./watchtower');
+const createWatchtowerClient = require('./watchtower-client');
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 const stat = promisify(fs.stat);
@@ -17,9 +25,29 @@ const DEFAULTS = {
   server: 'localhost:10001',
   macaroonPath: '',
   certEncoding: 'utf8',
+  services: ['lightning', 'walletUnlocker'],
   tls: /^darwin/.test(process.platform) // is macOS?
     ? `${HOME_DIR}/Library/Application Support/Lnd/tls.cert`
     : `${HOME_DIR}/.lnd/tls.cert`,
+};
+
+const SERVICES = {
+  lightning: {dir: null, filename: 'rpc.proto', create: createLightning},
+  walletUnlocker: {dir: null, filename: 'rpc.proto', create: createWalletUnlocker},
+  autopilot: {dir: 'autopilotrpc', filename: 'autopilot.proto', create: createAutopilot},
+  signer: {dir: 'signrpc', filename: 'signer.proto', create: createSigner},
+  chainNotifier: {dir: 'chainrpc', filename: 'chainnotifier.proto', create: createChainNotifier},
+  invoices: {dir: 'invoicesrpc', filename: 'invoices.proto', create: createInvoices},
+  router: {dir: 'routerrpc', filename: 'router.proto', create: createRouter},
+  walletKit: {dir: 'walletrpc', filename: 'walletkit.proto', create: createWalletKit},
+  watchtower: {dir: 'watchtowerrpc', filename: 'watchtower.proto', create: createWatchtower},
+  watchtowerClient: {dir: 'wtclientrpc', filename: 'wtclient.proto', create: createWatchtowerClient},
+};
+
+const asyncForEach = async (array, callback) => {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index, array);
+  }
 };
 
 /**
@@ -36,8 +64,7 @@ const DEFAULTS = {
  */
 module.exports = async function createLnprc(config = {}) {
   const rootPath = await pkgDir(__dirname);
-  const protoSrc = join(rootPath, 'node_modules/lnd/lnrpc/rpc.proto');
-  const protoDest = join(rootPath, 'rpc.proto');
+  const lnrpcPath = 'node_modules/lnd/lnrpc';
 
   /*
    Configuration options
@@ -50,6 +77,14 @@ module.exports = async function createLnprc(config = {}) {
     lightning,
     walletUnlocker,
     macaroonPath,
+    autopilot,
+    signer,
+    chainNotifier,
+    invoices,
+    router,
+    walletKit,
+    watchtower,
+    watchtowerClient
   } = Object.assign({}, DEFAULTS, config);
 
   // Generate grpc SSL credentials
@@ -117,51 +152,52 @@ module.exports = async function createLnprc(config = {}) {
     );
   }
 
-  /*
-   Write `rpc.proto` if none exists
-   */
-  try {
-    await stat(protoDest);
-  } catch (e) {
-    // file doesn't exist
-    let grpcSrc = await readFile(protoSrc, 'utf8');
+  const lnrpcSkeleton = {};
 
-    // remove google annotations causing parse error on `grpc.load()`
-    grpcSrc = grpcSrc.replace('import "google/api/annotations.proto";', '');
-    await writeFile(protoDest, grpcSrc);
-  }
+  await asyncForEach(config.services, async (serviceName) => {
+    const service = SERVICES[serviceName];
+    let protoDir = lnrpcPath;
+    if (service.dir) {
+      protoDir += `/${service.dir}`;
+    }
+    const protoSrc = join(rootPath, `${protoDir}/${service.filename}`);
+    const protoDest = join(rootPath, service.filename);
 
-  /**
-   * Create RPC from proto and return GRPC
-   * @type {grpc.PackageDefinition}
-   */
-  let grpcPkgObj;
+    try {
+      await stat(protoDest);
+    } catch (e) {
+      let grpcSrc = await readFile(protoSrc, 'utf8');
 
-  try {
-    const packageDefinition = await grpcLoader.load(protoDest, {
-      keepCase: true, // prevent conversion to camel case
-    });
-    grpcPkgObj = grpc.loadPackageDefinition(packageDefinition);
-  } catch (e) {
-    if (!e.code) e.code = 'GRPC_LOAD_ERR';
-    throw e;
-  }
+      grpcSrc = grpcSrc.replace('import "google/api/annotations.proto";', '');
+      await writeFile(protoDest, grpcSrc);
+    }
+
+    let grpcPkgObj;
+
+    try {
+      const packageDefinition = await grpcLoader.load(protoDest, {
+        keepCase: true, // prevent conversion to camel case
+      });
+      grpcPkgObj = grpc.loadPackageDefinition(packageDefinition);
+    } catch (e) {
+      if (!e.code) e.code = 'GRPC_LOAD_ERR';
+      throw e;
+    }
+
+    lnrpcSkeleton[serviceName] = {
+      value: this[serviceName] || service.create(grpcPkgObj, server, credentials, config),
+    };
+
+    if (serviceName === 'lightning') {
+      lnrpcSkeleton.description = {value: grpcPkgObj};
+    }
+  });
 
   /**
    * Lnrpc instance
    * @type {lnrpc}
    */
-  const lnrpc = Object.create(null, {
-    description: {value: grpcPkgObj},
-    lightning: {
-      value:
-        lightning || createLightning(grpcPkgObj, server, credentials, config),
-    },
-    walletUnlocker: {
-      value:
-        walletUnlocker || createWalletUnlocker(grpcPkgObj, server, credentials),
-    },
-  });
+  const lnrpc = Object.create(null, lnrpcSkeleton);
 
   return new Proxy(lnrpc, {
     /**

--- a/lib/router.js
+++ b/lib/router.js
@@ -1,0 +1,62 @@
+const {promisify} = require('util');
+
+const DEFAULTS = {
+  subscriptionMethods: [
+    'sendPayment',
+    'trackPayment',
+  ],
+};
+
+/**
+ * Factory for a Router GRPC service proxy
+ *
+ * Proxy serves two purposes:
+ *  - Wrap non-subscription methods in promises
+ *  - Immediately return subscription methods and properties
+ *
+ * @param  {grpc.PackageDefinition}   lnrpcDescriptor
+ * @param  {String}                   server
+ * @param  {Object}                   credentials
+ * @param  {Object}                   config
+ * @return {Proxy}
+ */
+module.exports = function createRouterProxy(
+  lnrpcDescriptor,
+  server,
+  credentials,
+  config = {}
+) {
+  // Configuration options
+  const {subscriptionMethods} = Object.assign({}, DEFAULTS, config);
+
+  /**
+   * GRPC Router Service
+   * @type {lnrpc.Router}
+   */
+  let router;
+
+  try {
+    router = new lnrpcDescriptor.routerrpc.Router(server, credentials);
+  } catch (e) {
+    if (!e.code) e.code = 'GRPC_ROUTER_SERVICE_ERR';
+    throw e;
+  }
+
+  return new Proxy(router, {
+    /**
+     * Promisify any requested (non-subscription) router RPC method
+     * @param  {lnrpc.Router} target
+     * @param  {String}          key
+     * @return {Any}
+     */
+    get(target, key) {
+      const method = target[key];
+
+      if (typeof method !== 'function' || subscriptionMethods.includes(key)) {
+        return target[key]; // forward
+      } else {
+        return promisify(method);
+      }
+    },
+  });
+};

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -1,0 +1,61 @@
+const {promisify} = require('util');
+
+const DEFAULTS = {
+  subscriptionMethods: [
+
+  ],
+};
+
+/**
+ * Factory for a Signer GRPC service proxy
+ *
+ * Proxy serves two purposes:
+ *  - Wrap non-subscription methods in promises
+ *  - Immediately return subscription methods and properties
+ *
+ * @param  {grpc.PackageDefinition}   lnrpcDescriptor
+ * @param  {String}                   server
+ * @param  {Object}                   credentials
+ * @param  {Object}                   config
+ * @return {Proxy}
+ */
+module.exports = function createSignerProxy(
+  lnrpcDescriptor,
+  server,
+  credentials,
+  config = {}
+) {
+  // Configuration options
+  const {subscriptionMethods} = Object.assign({}, DEFAULTS, config);
+
+  /**
+   * GRPC Signer Service
+   * @type {lnrpc.Signer}
+   */
+  let signer;
+
+  try {
+    signer = new lnrpcDescriptor.signrpc.Signer(server, credentials);
+  } catch (e) {
+    if (!e.code) e.code = 'GRPC_SIGNER_SERVICE_ERR';
+    throw e;
+  }
+
+  return new Proxy(signer, {
+    /**
+     * Promisify any requested (non-subscription) signer RPC method
+     * @param  {lnrpc.Signer} target
+     * @param  {String}          key
+     * @return {Any}
+     */
+    get(target, key) {
+      const method = target[key];
+
+      if (typeof method !== 'function' || subscriptionMethods.includes(key)) {
+        return target[key]; // forward
+      } else {
+        return promisify(method);
+      }
+    },
+  });
+};

--- a/lib/wallet-kit.js
+++ b/lib/wallet-kit.js
@@ -1,0 +1,61 @@
+const {promisify} = require('util');
+
+const DEFAULTS = {
+  subscriptionMethods: [
+
+  ],
+};
+
+/**
+ * Factory for a WalletKit GRPC service proxy
+ *
+ * Proxy serves two purposes:
+ *  - Wrap non-subscription methods in promises
+ *  - Immediately return subscription methods and properties
+ *
+ * @param  {grpc.PackageDefinition}   lnrpcDescriptor
+ * @param  {String}                   server
+ * @param  {Object}                   credentials
+ * @param  {Object}                   config
+ * @return {Proxy}
+ */
+module.exports = function createWalletKitProxy(
+  lnrpcDescriptor,
+  server,
+  credentials,
+  config = {}
+) {
+  // Configuration options
+  const {subscriptionMethods} = Object.assign({}, DEFAULTS, config);
+
+  /**
+   * GRPC WalletKit Service
+   * @type {lnrpc.WalletKit}
+   */
+  let walletKit;
+
+  try {
+    walletKit = new lnrpcDescriptor.walletrpc.WalletKit(server, credentials);
+  } catch (e) {
+    if (!e.code) e.code = 'GRPC_WALLET_KIT_SERVICE_ERR';
+    throw e;
+  }
+
+  return new Proxy(walletKit, {
+    /**
+     * Promisify any requested (non-subscription) walletKit RPC method
+     * @param  {lnrpc.WalletKit} target
+     * @param  {String}          key
+     * @return {Any}
+     */
+    get(target, key) {
+      const method = target[key];
+
+      if (typeof method !== 'function' || subscriptionMethods.includes(key)) {
+        return target[key]; // forward
+      } else {
+        return promisify(method);
+      }
+    },
+  });
+};

--- a/lib/watchtower-client.js
+++ b/lib/watchtower-client.js
@@ -1,0 +1,61 @@
+const {promisify} = require('util');
+
+const DEFAULTS = {
+  subscriptionMethods: [
+
+  ],
+};
+
+/**
+ * Factory for a WatchtowerClient GRPC service proxy
+ *
+ * Proxy serves two purposes:
+ *  - Wrap non-subscription methods in promises
+ *  - Immediately return subscription methods and properties
+ *
+ * @param  {grpc.PackageDefinition}   lnrpcDescriptor
+ * @param  {String}                   server
+ * @param  {Object}                   credentials
+ * @param  {Object}                   config
+ * @return {Proxy}
+ */
+module.exports = function createWatchtowerClientProxy(
+  lnrpcDescriptor,
+  server,
+  credentials,
+  config = {}
+) {
+  // Configuration options
+  const {subscriptionMethods} = Object.assign({}, DEFAULTS, config);
+
+  /**
+   * GRPC WatchtowerClient Service
+   * @type {lnrpc.WatchtowerClient}
+   */
+  let watchtowerClient;
+
+  try {
+    watchtowerClient = new lnrpcDescriptor.wtclientrpc.WatchtowerClient(server, credentials);
+  } catch (e) {
+    if (!e.code) e.code = 'GRPC_WATCHTOWER_CLIENT_SERVICE_ERR';
+    throw e;
+  }
+
+  return new Proxy(watchtowerClient, {
+    /**
+     * Promisify any requested (non-subscription) watchtowerClient RPC method
+     * @param  {lnrpc.WatchtowerClient} target
+     * @param  {String}          key
+     * @return {Any}
+     */
+    get(target, key) {
+      const method = target[key];
+
+      if (typeof method !== 'function' || subscriptionMethods.includes(key)) {
+        return target[key]; // forward
+      } else {
+        return promisify(method);
+      }
+    },
+  });
+};

--- a/lib/watchtower.js
+++ b/lib/watchtower.js
@@ -1,0 +1,61 @@
+const {promisify} = require('util');
+
+const DEFAULTS = {
+  subscriptionMethods: [
+
+  ],
+};
+
+/**
+ * Factory for a Watchtower GRPC service proxy
+ *
+ * Proxy serves two purposes:
+ *  - Wrap non-subscription methods in promises
+ *  - Immediately return subscription methods and properties
+ *
+ * @param  {grpc.PackageDefinition}   lnrpcDescriptor
+ * @param  {String}                   server
+ * @param  {Object}                   credentials
+ * @param  {Object}                   config
+ * @return {Proxy}
+ */
+module.exports = function createWatchtowerProxy(
+  lnrpcDescriptor,
+  server,
+  credentials,
+  config = {}
+) {
+  // Configuration options
+  const {subscriptionMethods} = Object.assign({}, DEFAULTS, config);
+
+  /**
+   * GRPC Watchtower Service
+   * @type {lnrpc.Watchtower}
+   */
+  let watchtower;
+
+  try {
+    watchtower = new lnrpcDescriptor.watchtowerrpc.Watchtower(server, credentials);
+  } catch (e) {
+    if (!e.code) e.code = 'GRPC_WATCHTOWER_SERVICE_ERR';
+    throw e;
+  }
+
+  return new Proxy(watchtower, {
+    /**
+     * Promisify any requested (non-subscription) watchtower RPC method
+     * @param  {lnrpc.Watchtower} target
+     * @param  {String}          key
+     * @return {Any}
+     */
+    get(target, key) {
+      const method = target[key];
+
+      if (typeof method !== 'function' || subscriptionMethods.includes(key)) {
+        return target[key]; // forward
+      } else {
+        return promisify(method);
+      }
+    },
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lnrpc",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "User-centric Node.js gRPC client for lightningnetwork/lnd",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@grpc/proto-loader": "^0.3.0",
-    "grpc": "^1.14.0-pre2",
+    "grpc": "1.24.2",
     "napa": "^3.0.0",
     "pkg-dir": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,13 +54,26 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
+"@types/bytebuffer@^5.0.40":
+  version "5.0.40"
+  resolved "https://registry.yarnpkg.com/@types/bytebuffer/-/bytebuffer-5.0.40.tgz#d6faac40dcfb09cd856cdc4c01d3690ba536d3ee"
+  integrity sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==
+  dependencies:
+    "@types/long" "*"
+    "@types/node" "*"
+
 "@types/lodash@^4.14.104":
   version "4.14.115"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.115.tgz#54d171b2ce12c058742443b5f6754760f701b8f9"
 
-"@types/long@^4.0.0":
+"@types/long@*", "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
+
+"@types/node@*":
+  version "12.12.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.20.tgz#7b693038ce661fe57a7ffa4679440b5e7c5e8b99"
+  integrity sha512-VAe+DiwpnC/g448uN+/3gRl4th0BTdrR9gSLIOHA+SUQskaYZQDOHG7xmjiE7JUhjbXnbXytf6Ih+/pA6CtMFQ==
 
 "@types/node@^10.1.0":
   version "10.5.5"
@@ -266,9 +279,10 @@ chalk@^2.0.0, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chownr@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+chownr@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
+  integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -825,13 +839,16 @@ growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
-grpc@^1.14.0-pre2:
-  version "1.14.0-pre2"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.14.0-pre2.tgz#60b7273da9ad9ad7ce2369245c9e0a404f513b4e"
+grpc@1.24.2:
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.24.2.tgz#76d047bfa7b05b607cbbe3abb99065dcefe0c099"
+  integrity sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==
   dependencies:
-    lodash "^4.17.5"
-    nan "^2.0.0"
-    node-pre-gyp "^0.10.0"
+    "@types/bytebuffer" "^5.0.40"
+    lodash.camelcase "^4.3.0"
+    lodash.clone "^4.5.0"
+    nan "^2.13.2"
+    node-pre-gyp "^0.14.0"
     protobufjs "^5.0.3"
 
 has-ansi@^2.0.0:
@@ -1096,6 +1113,16 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
+lodash.clone@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
+  integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
+
 lodash.create@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
@@ -1179,18 +1206,27 @@ minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-minipass@^2.2.1, minipass@^2.3.3:
+minipass@^2.2.1:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.3.tgz#a7dcc8b7b833f5d368759cce544dccb55f50f233"
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minizlib@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
+minipass@^2.8.6, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
   dependencies:
-    minipass "^2.2.1"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.2.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
+  dependencies:
+    minipass "^2.9.0"
 
 mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
@@ -1223,9 +1259,10 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.0.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+nan@^2.13.2:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
 napa@^3.0.0:
   version "3.0.0"
@@ -1254,9 +1291,10 @@ needle@^2.2.1:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
-node-pre-gyp@^0.10.0:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+node-pre-gyp@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
+  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -1267,7 +1305,7 @@ node-pre-gyp@^0.10.0:
     rc "^1.2.7"
     rimraf "^2.6.1"
     semver "^5.3.0"
-    tar "^4"
+    tar "^4.4.2"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -1729,17 +1767,18 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-tar@^4:
-  version "4.4.6"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
+tar@^4.4.2:
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
   dependencies:
-    chownr "^1.0.1"
+    chownr "^1.1.1"
     fs-minipass "^1.2.5"
-    minipass "^2.3.3"
-    minizlib "^1.1.0"
+    minipass "^2.8.6"
+    minizlib "^1.2.1"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
-    yallist "^3.0.2"
+    yallist "^3.0.3"
 
 text-table@~0.2.0:
   version "0.2.0"
@@ -1878,9 +1917,14 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yallist@^3.0.0, yallist@^3.0.2:
+yallist@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+
+yallist@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs@^3.10.0:
   version "3.32.0"


### PR DESCRIPTION
This adds support for all of the rpc subservices that lnd exposes.  The original implementation of lnrpc was loading only the services found in rpc.proto (lightning, walletUnlocker).  

I ended up refactoring a lot of how lnrpc.js works by allowing a user pass which services they want to load (defaults to [lightning, walletUnlocker) so it won't break existing users. 

I also bumped the version number and the version of grpc being used. 

This works fine for the project I needed subservices for (router, signer) but probably needs to be cleaned up further to be merged into master.

The old code exposed all of the lightning and walletUnlocker methods on the root lnrpc object.  This presents a problem because some of the subservices share the same method names as those found in the lightning service.  For now I did not change how this works so if you want to use a subservice you are required to use it directly (e.g. lnrpc.signer.verifyMessage({})) whereas if you used lnrpc.verifyMessage it would default to the method exposed by the lightning service.